### PR TITLE
prevent extra outptus with to_xml

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
 
     if args.format == "xml":
         to_xml(res, tagged_doc)
-    if args.format == "prolog":
+    elif args.format == "prolog":
         to_prolog(res, tagged_doc)
     elif args.format == "html":
         to_mathml(res, file=sys.stdout)


### PR DESCRIPTION
Maybe this is a bug? Originally, when the output format is xml, it also outputs some extra information, maybe through the final `else` statement.