### PR TITLE
Adapt to the latest version of chainer

### DIFF
--- a/depccg/chainer/fixed_length_n_step_lstm.py
+++ b/depccg/chainer/fixed_length_n_step_lstm.py
@@ -10,14 +10,14 @@ from chainer.links import NStepLSTM
 import chainer.functions as F
 
 from chainer import cuda
-from chainer.functions.activation import lstm
+from chainer.functions import lstm
 from chainer.functions.array import concat
 from chainer.functions.array import reshape
 from chainer.functions.array import split_axis
 from chainer.functions.array import stack
 from chainer.functions.connection import linear
 from chainer.functions.noise import dropout
-from chainer.functions.connection.n_step_lstm import NStepLSTM as NStepLSTMFunction
+from chainer.links import NStepLSTM as NStepLSTMFunction
 
 
 # if cuda.cudnn_enabled:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cython
 lxml
 pyyaml
 nltk
-chainer>=2.0.0, <=6.7.0
+chainer>=2.0.0
 googledrivedownloader
 requests
 allennlp


### PR DESCRIPTION
Chainer 6.7.0 requires typing-sextensions 3.6.0, which is incompatble with torch 1.9.0 at runtime (in fact, the requirements of PyTorch's is loose). On the other hand, chainer 7.8.0 is compatible with typing-extensions 3.10.0.0 and hence with the latest torch.

Some package importing needs to be updated to catch up with the latest version of chainer. As far as the older versions of docs suggest, the changes this commit makes should cause no problems and carry over to v.2.0.2.