### PR TITLE
Fix LSTM call

### DIFF
--- a/depccg/chainer/fixed_length_n_step_lstm.py
+++ b/depccg/chainer/fixed_length_n_step_lstm.py
@@ -416,7 +416,7 @@ def fixed_length_n_step_lstm(
                 lstm_in = linear.linear(x, xws[layer], xbs[layer]) + \
                           linear.linear(h, hws[layer], hbs[layer])
 
-                c_bar, h_bar = lstm.lstm(c, lstm_in)
+                c_bar, h_bar = lstm(c, lstm_in)
                 if h_rest is not None:
                     h = concat.concat([h_bar, h_rest], axis=0)
                     c = concat.concat([c_bar, c_rest], axis=0)


### PR DESCRIPTION
Otherwise I get the error:
```
  ...
  File ".../depccg/depccg/__main__.py", line 166, in <module>
    parse_args(main)
  File ".../depccg/depccg/argparse.py", line 203, in parse_args
    args.func(args)
  File ".../depccg/depccg/__main__.py", line 126, in main
    score_result, categories_ = supertagger.predict_doc(
  File ".../depccg/depccg/chainer/lstm_parser_bi_fast.py", line 203, in predict_doc
    pred = self._predict(batch)
  File ".../depccg/depccg/chainer/lstm_parser_bi_fast.py", line 189, in _predict
    cat_ys, dep_ys = self.forward(ws, ss, ps, ls)
  File ".../depccg/depccg/chainer/lstm_parser_bi_fast.py", line 151, in forward
    _, _, hs_f = self.lstm_f(hx_f, cx_f, xs_f, train=False)
  File ".../depccg/depccg/chainer/fixed_length_n_step_lstm.py", line 138, in __call__
    hy, cy, ys = fixed_length_n_step_lstm(
  File ".../depccg/depccg/chainer/fixed_length_n_step_lstm.py", line 419, in fixed_length_n_step_lstm
    c_bar, h_bar = lstm.lstm(c, lstm_in)
AttributeError: 'function' object has no attribute 'lstm'
```