### PR TITLE
[fix] to ensure that the category containing double parentheses is properly processed

### DIFF
--- a/depccg/cat.py
+++ b/depccg/cat.py
@@ -137,6 +137,8 @@ class Category(object):
             elif item in '(<':
                 pass
             elif item in ')>':
+                if len(buffer) >= 1 and buffer[-1] in ')>':
+                    buffer.pop()
                 y = stack.pop()
                 if len(stack) == 0:
                     return y


### PR DESCRIPTION
- Why PR: A tiny change in cat.py seems to be necessary.
- What problem: Fail to load a category that contains double parentheses inside.  For example, transitive verbs in Japanese CCGBank.
- Suggestion: Add a conditional sentence to discard the second parenthesis if double parentheses appear inside a category. 