### PR TITLE
Add continuous integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v10
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v10
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
           python-version: "3.14"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
       - uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
+          save-cache: false
           python-version: "3.14"
       - name: Build sdist and wheel
         run: uv build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v10
+        with:
+          enable-cache: true
+          python-version: ${{ matrix.python-version }}
+      - name: Install the project
+        run: uv sync --frozen
+      - name: Run tests
+        run: uv run --frozen pytest
+
+  package:
+    name: Build and install package
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v10
+        with:
+          enable-cache: true
+          python-version: "3.14"
+      - name: Build sdist and wheel
+        run: uv build
+      - name: Install wheel in a clean environment
+        run: |
+          uv venv --python 3.14 "$RUNNER_TEMP/depccg-wheel"
+          uv pip install --python "$RUNNER_TEMP/depccg-wheel/bin/python" dist/*.whl
+      - name: Smoke-test installed wheel
+        working-directory: ${{ runner.temp }}
+        run: |
+          depccg_python="$RUNNER_TEMP/depccg-wheel/bin/python"
+          "$depccg_python" -c "import depccg._parsing, depccg.morpha"
+          "$RUNNER_TEMP/depccg-wheel/bin/depccg_en" --help >/dev/null
+          "$RUNNER_TEMP/depccg-wheel/bin/depccg_ja" --help >/dev/null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
         with:
           enable-cache: true
           save-cache: false
+          # Build release artifacts on the newest supported Python; the test
+          # matrix above covers runtime compatibility with every other version.
           python-version: "3.14"
       - name: Build sdist and wheel
         run: uv build


### PR DESCRIPTION
## Summary

- run the full test suite on Python 3.10 through 3.14
- build the sdist and wheel on every pull request
- install the generated wheel into a clean environment
- smoke-test the compiled extensions and English/Japanese CLI entry points from the installed wheel

## Why

depccg includes Cython/C++ extensions and supports several Python versions. This workflow checks both source development installs and the artifact users will install, catching packaging failures that source-only tests would miss.

Large pretrained models are intentionally excluded from per-PR CI. The v3 migration validated all supported models separately against their legacy implementations; downloading several hundred megabytes from Google Drive on every change would make required checks slow and fragile.

## Local verification

- workflow YAML parsed successfully
- `git diff --check` passed
- the same frozen uv install, full test suite, build, clean-wheel installation, compiled-extension import, and CLI smoke tests were run locally before this PR
