### PR TITLE
Make pyproject the dependency source

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,6 @@
 include bin/*
 include README.md
 include LICENSE
-include requirements.txt
 recursive-include c *
 recursive-include depccg *.pyx *.pxd *.h
 exclude c/*.d

--- a/README.md
+++ b/README.md
@@ -21,6 +21,25 @@ Using pip:
 ➜ pip install depccg
 ```
 
+### Development
+
+Project metadata and dependencies are defined in `pyproject.toml` and locked in
+`uv.lock`. To create a reproducible development environment and run the tests:
+
+```sh
+➜ uv sync --frozen
+➜ uv run --frozen pytest
+```
+
+To build the source distribution and wheel:
+
+```sh
+➜ uv build
+```
+
+`setup.py` is retained only for the native Cython/C++ extension definitions;
+package metadata and dependencies must be changed in `pyproject.toml`.
+
 ## Usage
 
 ### Using a pretrained English parser

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,0 @@
-simplejson
-cython
-lxml
-pyyaml
-nltk
-requests
-janome
-torch>=2.0
-tqdm


### PR DESCRIPTION
## Summary

- make `pyproject.toml` the single source of truth for project dependencies
- remove the duplicate and already-divergent `requirements.txt`
- document frozen uv setup, testing, and package build commands
- document why `setup.py` remains in the project

## Why

The requirements file duplicated runtime dependencies from `pyproject.toml`, omitted NumPy, and listed Cython as though it were a runtime dependency. Keeping both files would allow them to drift further. Runtime and build requirements are already represented correctly in `pyproject.toml`, while `uv.lock` provides reproducible development resolution.

`setup.py` is intentionally retained. The native build compiles a C source separately and links it into a Cython/C++ extension; attempting to flatten that into a simple setuptools source list passes C++-only flags to the C compiler and fails. Package metadata and dependency declarations do not live there.

## Verification

- `uv sync --frozen`
- `uv run --frozen pytest` (`3606 passed, 1 skipped`)
- `uv build`
- verified the resulting sdist no longer contains `requirements.txt`
- `git diff --check`

The CI introduced in #40 will additionally build and test this change on Python 3.10 through 3.14 and install the generated wheel in a clean environment.
