### PR TITLE
Add pretrained model smoke tests

### DIFF
--- a/.github/workflows/model-smoke.yml
+++ b/.github/workflows/model-smoke.yml
@@ -45,7 +45,7 @@ jobs:
           DEPCCG_HOME: ${{ runner.temp }}/depccg-models
         run: |
           uv run --frozen depccg_en download
-          output="$(echo "this is a test sentence ." | uv run --frozen depccg_en --format deriv --silent)"
+          output="$(echo "A quiet moon shines over the old temple ." | uv run --frozen depccg_en --format deriv --silent)"
           printf '%s\n' "$output"
           grep -q '^ID=1' <<<"$output"
           grep -q 'S\[dcl\]' <<<"$output"
@@ -55,7 +55,7 @@ jobs:
           DEPCCG_HOME: ${{ runner.temp }}/depccg-models
         run: |
           uv run --frozen depccg_ja download
-          output="$(echo "これはテストの文です。" | uv run --frozen depccg_ja --silent)"
+          output="$(echo "春の月が静かな海を照らしています。" | uv run --frozen depccg_ja --silent)"
           printf '%s\n' "$output"
           grep -q '^ID=1' <<<"$output"
           grep -q 'S\[mod=' <<<"$output"
@@ -83,7 +83,7 @@ jobs:
           DEPCCG_HOME: ${{ runner.temp }}/depccg-models
         run: |
           uv run --frozen depccg_en download "${{ matrix.model }}"
-          output="$(echo "this is a test sentence ." | uv run --frozen depccg_en --model "${{ matrix.model }}" --format deriv --silent)"
+          output="$(echo "A quiet moon shines over the old temple ." | uv run --frozen depccg_en --model "${{ matrix.model }}" --format deriv --silent)"
           printf '%s\n' "$output"
           grep -q '^ID=1' <<<"$output"
           grep -q 'S\[dcl\]' <<<"$output"

--- a/.github/workflows/model-smoke.yml
+++ b/.github/workflows/model-smoke.yml
@@ -1,0 +1,86 @@
+name: Pretrained model smoke tests
+
+on:
+  # Run when this workflow changes so the checks themselves are reviewable.
+  pull_request:
+    paths: [.github/workflows/model-smoke.yml]
+  schedule:
+    - cron: "17 3 * * 1"
+  workflow_dispatch:
+    inputs:
+      include_large_models:
+        description: Also test the English ELMo and Rebank models
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: model-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  basic-models:
+    name: ${{ matrix.language }} basic model
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [English, Japanese]
+
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v10.0.1
+        with:
+          enable-cache: true
+          python-version: "3.14"
+      - name: Install depccg
+        run: uv sync --frozen
+      - name: Download and test English basic model
+        if: matrix.language == 'English'
+        env:
+          DEPCCG_HOME: ${{ runner.temp }}/depccg-models
+        run: |
+          uv run --frozen depccg_en download
+          output="$(echo "this is a test sentence ." | uv run --frozen depccg_en --format deriv --silent)"
+          grep -q '^ID=1' <<<"$output"
+          grep -q 'S\[dcl\]' <<<"$output"
+      - name: Download and test Japanese basic model
+        if: matrix.language == 'Japanese'
+        env:
+          DEPCCG_HOME: ${{ runner.temp }}/depccg-models
+        run: |
+          uv run --frozen depccg_ja download
+          output="$(echo "これはテストの文です。" | uv run --frozen depccg_ja --silent)"
+          grep -q '^ID=1' <<<"$output"
+          grep -q 'S\[mod=' <<<"$output"
+
+  large-english-models:
+    if: github.event_name == 'workflow_dispatch' && inputs.include_large_models
+    name: English ${{ matrix.model }} model
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        model: [elmo, rebank]
+
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v10.0.1
+        with:
+          enable-cache: true
+          python-version: "3.14"
+      - name: Install depccg
+        run: uv sync --frozen
+      - name: Download and test model
+        env:
+          DEPCCG_HOME: ${{ runner.temp }}/depccg-models
+        run: |
+          uv run --frozen depccg_en download "${{ matrix.model }}"
+          output="$(echo "this is a test sentence ." | uv run --frozen depccg_en --model "${{ matrix.model }}" --format deriv --silent)"
+          grep -q '^ID=1' <<<"$output"
+          grep -q 'S\[dcl\]' <<<"$output"

--- a/.github/workflows/model-smoke.yml
+++ b/.github/workflows/model-smoke.yml
@@ -46,6 +46,7 @@ jobs:
         run: |
           uv run --frozen depccg_en download
           output="$(echo "this is a test sentence ." | uv run --frozen depccg_en --format deriv --silent)"
+          printf '%s\n' "$output"
           grep -q '^ID=1' <<<"$output"
           grep -q 'S\[dcl\]' <<<"$output"
       - name: Download and test Japanese basic model
@@ -55,6 +56,7 @@ jobs:
         run: |
           uv run --frozen depccg_ja download
           output="$(echo "これはテストの文です。" | uv run --frozen depccg_ja --silent)"
+          printf '%s\n' "$output"
           grep -q '^ID=1' <<<"$output"
           grep -q 'S\[mod=' <<<"$output"
 
@@ -82,5 +84,6 @@ jobs:
         run: |
           uv run --frozen depccg_en download "${{ matrix.model }}"
           output="$(echo "this is a test sentence ." | uv run --frozen depccg_en --model "${{ matrix.model }}" --format deriv --silent)"
+          printf '%s\n' "$output"
           grep -q '^ID=1' <<<"$output"
           grep -q 'S\[dcl\]' <<<"$output"


### PR DESCRIPTION
## Summary

- download and parse with the public English and Japanese basic models every week
- run the basic-model checks whenever this workflow changes
- offer a manual option to test the larger English ELMo and Rebank models
- verify real CLI output rather than only checking that entry points start

## Why

The regular CI verifies unit tests, package builds, native extensions, and CLI startup without depending on external model hosting. This complementary workflow exercises the README-level user path: download a published model and parse a sentence through the installed project.

The model checks are kept out of ordinary pull requests because the downloads are large and Google Drive availability should not block unrelated changes. English and Japanese basic run weekly; ELMo and Rebank run only when explicitly requested through `workflow_dispatch` with `include_large_models` enabled.

Model files are deliberately not cached. A cached checkpoint could let the job pass after the public download stopped working, defeating one purpose of this monitor.

## Verification

- workflow YAML parsed successfully
- `git diff --check` passed
- this PR triggers the English and Japanese basic jobs once so the workflow and public downloads can be reviewed before merge
