### PR TITLE
Build and publish PyPI distributions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,58 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Test and build distributions
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v10.0.1
+        with:
+          enable-cache: true
+          python-version: "3.14"
+      - name: Verify tag matches package version
+        run: |
+          package_version="$(python -c 'import pathlib, tomllib; print(tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"])')"
+          test "$GITHUB_REF_NAME" = "v$package_version"
+      - name: Install and test
+        run: |
+          uv sync --frozen
+          uv run --frozen pytest
+      # depccg contains a native extension. Build platform wheels separately
+      # with a manylinux-compatible toolchain before publishing any wheels.
+      - name: Build source distribution
+        run: uv build --sdist
+      - uses: actions/upload-artifact@v7.0.1
+        with:
+          name: python-distributions
+          path: dist/*.tar.gz
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: Publish distributions
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/depccg
+    permissions:
+      id-token: write
+
+    steps:
+      - uses: actions/download-artifact@v8.0.1
+        with:
+          name: python-distributions
+          path: dist/
+      - name: Publish distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.14.2
+        with:
+          packages-dir: dist/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,15 +70,24 @@ jobs:
           - platform: Linux
             arch: x86_64
             runner: ubuntu-latest
+            pr_build: cp314-*
+            release_build: cp3{10,11,12,13,14}-*
           - platform: Linux
             arch: aarch64
             runner: ubuntu-24.04-arm
+            pr_build: cp314-*
+            release_build: cp3{10,11,12,13,14}-*
           - platform: macOS
             arch: x86_64
             runner: macos-15-intel
+            # PyTorch does not provide Intel Mac wheels after Python 3.12.
+            pr_build: cp312-*
+            release_build: cp3{10,11,12}-*
           - platform: macOS
             arch: arm64
             runner: macos-14
+            pr_build: cp314-*
+            release_build: cp3{10,11,12,13,14}-*
 
     steps:
       - uses: actions/checkout@v7
@@ -90,7 +99,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.arch }}
           # PRs exercise one wheel per platform. Release tags build the full
           # supported Python matrix configured in pyproject.toml.
-          CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp314-*' || 'cp3{10,11,12,13,14}-*' }}
+          CIBW_BUILD: ${{ github.event_name == 'pull_request' && matrix.pr_build || matrix.release_build }}
         with:
           output-dir: wheelhouse
       - uses: actions/upload-artifact@v7.0.1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,14 @@
-name: Publish to PyPI
+name: Build and publish distributions
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/publish.yml
+      - pyproject.toml
+      - setup.py
+      - c/**
+      - depccg/*.pyx
+      - depccg/*.h
   push:
     tags: ["v*"]
 
@@ -8,17 +16,20 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    name: Test and build distributions
+  validate:
+    name: Validate release
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
           python-version: "3.14"
       - name: Verify tag matches package version
+        if: github.event_name == 'push'
         run: |
           package_version="$(python -c 'import pathlib, tomllib; print(tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"])')"
           test "$GITHUB_REF_NAME" = "v$package_version"
@@ -26,20 +37,73 @@ jobs:
         run: |
           uv sync --frozen
           uv run --frozen pytest
-      # depccg contains a native extension. Build platform wheels separately
-      # with a manylinux-compatible toolchain before publishing any wheels.
-      - name: Build source distribution
-        run: uv build --sdist
+
+  sdist:
+    name: Build source distribution
+    needs: validate
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@v10.0.1
+        with:
+          enable-cache: true
+          python-version: "3.14"
+      - run: uv build --sdist
       - uses: actions/upload-artifact@v7.0.1
         with:
-          name: python-distributions
+          name: distributions-sdist
           path: dist/*.tar.gz
+          if-no-files-found: error
+          retention-days: 7
+
+  wheels:
+    name: Wheel (${{ matrix.platform }}, ${{ matrix.arch }})
+    needs: validate
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: Linux
+            arch: x86_64
+            runner: ubuntu-latest
+          - platform: Linux
+            arch: aarch64
+            runner: ubuntu-24.04-arm
+          - platform: macOS
+            arch: x86_64
+            runner: macos-15-intel
+          - platform: macOS
+            arch: arm64
+            runner: macos-14
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Build and test wheels
+        uses: pypa/cibuildwheel@v4.1.0
+        env:
+          CIBW_ARCHS: ${{ matrix.arch }}
+          # PRs exercise one wheel per platform. Release tags build the full
+          # supported Python matrix configured in pyproject.toml.
+          CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp314-*' || 'cp3{10,11,12,13,14}-*' }}
+        with:
+          output-dir: wheelhouse
+      - uses: actions/upload-artifact@v7.0.1
+        with:
+          name: distributions-${{ matrix.platform }}-${{ matrix.arch }}
+          path: wheelhouse/*.whl
           if-no-files-found: error
           retention-days: 7
 
   publish:
     name: Publish distributions
-    needs: build
+    if: github.event_name == 'push'
+    needs: [sdist, wheels]
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -50,8 +114,9 @@ jobs:
     steps:
       - uses: actions/download-artifact@v8.0.1
         with:
-          name: python-distributions
+          pattern: distributions-*
           path: dist/
+          merge-multiple: true
       - name: Publish distributions to PyPI
         uses: pypa/gh-action-pypi-publish@v1.14.2
         with:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,8 +3,9 @@
 Releases are published to PyPI by `.github/workflows/publish.yml` when a version
 tag is pushed. The workflow tests the tagged revision and builds a source
 distribution plus wheels for Python 3.10 through 3.14 on Linux x86_64/aarch64
-and macOS x86_64/arm64. It publishes with PyPI Trusted Publishing and does not
-use a stored API token.
+and macOS arm64. Intel macOS wheels cover Python 3.10 through 3.12, matching the
+versions for which PyTorch provides Intel macOS wheels. The workflow publishes
+with PyPI Trusted Publishing and does not use a stored API token.
 
 ## One-time setup
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,9 +1,10 @@
 # Releasing depccg
 
 Releases are published to PyPI by `.github/workflows/publish.yml` when a version
-tag is pushed. The workflow tests the tagged revision, builds a source
-distribution, and publishes with PyPI Trusted Publishing. It does not use a
-stored API token.
+tag is pushed. The workflow tests the tagged revision and builds a source
+distribution plus wheels for Python 3.10 through 3.14 on Linux x86_64/aarch64
+and macOS x86_64/arm64. It publishes with PyPI Trusted Publishing and does not
+use a stored API token.
 
 ## One-time setup
 
@@ -36,7 +37,5 @@ stored API token.
 
 The workflow rejects a tag whose name does not exactly match the version in
 `pyproject.toml`. Published PyPI files are immutable, so never reuse a released
-version number. depccg has historically published source distributions because
-it contains a native extension. Do not publish a wheel produced directly on a
-GitHub-hosted runner; add a platform-wheel build using a compatible toolchain
-first.
+version number. Windows wheels are not currently built because the native
+extension build uses Unix `make`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,42 @@
+# Releasing depccg
+
+Releases are published to PyPI by `.github/workflows/publish.yml` when a version
+tag is pushed. The workflow tests the tagged revision, builds a source
+distribution, and publishes with PyPI Trusted Publishing. It does not use a
+stored API token.
+
+## One-time setup
+
+1. Create a GitHub environment named `pypi`. Adding required reviewers and
+   restricting deployments to protected version tags is recommended.
+2. In the PyPI `depccg` project settings, add a GitHub Actions Trusted Publisher
+   with these values:
+
+   - Owner: `masashi-y`
+   - Repository: `depccg`
+   - Workflow: `publish.yml`
+   - Environment: `pypi`
+
+## Publishing a release
+
+1. Update the version in `pyproject.toml` and run `uv lock`.
+2. Replace `Unreleased` in `CHANGELOG.md` with the release date.
+3. Open and merge a release preparation pull request. Confirm that CI and the
+   pretrained model smoke tests pass.
+4. Tag the merge commit with the same version, prefixed by `v`, and push it:
+
+   ```sh
+   git tag -a v3.0.0 -m "depccg 3.0.0"
+   git push origin v3.0.0
+   ```
+
+5. Approve the `pypi` environment deployment if protection rules require it.
+6. Verify the new files and metadata on PyPI, then test installation in a fresh
+   environment.
+
+The workflow rejects a tag whose name does not exactly match the version in
+`pyproject.toml`. Published PyPI files are immutable, so never reuse a released
+version number. depccg has historically published source distributions because
+it contains a native extension. Do not publish a wheel produced directly on a
+GitHub-hosted runner; add a platform-wheel build using a compatible toolchain
+first.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,11 @@ Repository = "https://github.com/masashi-y/depccg"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 
+[tool.cibuildwheel]
+build = "cp3{10,11,12,13,14}-*"
+skip = "*-musllinux_*"
+test-command = "python -c 'import depccg._parsing, depccg.morpha' && depccg_en --help >/dev/null && depccg_ja --help >/dev/null"
+
 [tool.setuptools.package-data]
 depccg = ["models/*.json", "models/*.yaml", "models/*.list"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ testpaths = ["tests"]
 
 [tool.cibuildwheel]
 build = "cp3{10,11,12,13,14}-*"
-skip = "*-musllinux_*"
+skip = "*-musllinux_* cp31{3,4}-macosx_x86_64"
 test-command = "python -c 'import depccg._parsing, depccg.morpha' && depccg_en --help >/dev/null && depccg_ja --help >/dev/null"
 
 [tool.setuptools.package-data]


### PR DESCRIPTION
## Summary

- publish matching version tags to PyPI using Trusted Publishing
- build an sdist and tested wheels with cibuildwheel
- provide Python 3.10–3.14 wheels for Linux x86_64/aarch64 and macOS arm64
- provide Python 3.10–3.12 wheels for macOS x86_64, matching PyTorch availability
- deliberately leave Windows unsupported because the native build uses Unix `make`
- document the one-time setup and release procedure

## Wheel validation

Every built wheel is installed and smoke-tested by importing both native extensions and invoking the English and Japanese CLI help. Pull requests build the newest installable Python for each platform; a release tag builds the complete supported matrix.

PR validation passed for all four targets:

- Linux x86_64 / Python 3.14
- Linux aarch64 / Python 3.14
- macOS arm64 / Python 3.14
- macOS x86_64 / Python 3.12

## Other verification

- source distribution build passed in CI
- regular Python 3.10–3.14 CI passed
- local `uvx twine check dist/depccg-3.0.0.tar.gz` passed
- locally installed the generated sdist into an isolated Python 3.14 environment and invoked `depccg_en --help`

## Setup required before the first release

Create the `pypi` GitHub environment and configure the matching PyPI Trusted Publisher as documented in `RELEASING.md`. No package is published merely by merging this PR; publishing starts only when a matching `v*` tag is pushed.

The existing flaky `Bilinear` test (uninitialized parameters can occasionally contain NaN) is intentionally not changed here and will be handled in a separate PR.