### PR TITLE
Prepare 3.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This changelog covers depccg v3 and later releases.
 
-## [3.0.0] - Unreleased
+## [3.0.0] - 2026-08-15
 
 ### Added
 


### PR DESCRIPTION
## Summary

- mark depccg 3.0.0 as released on 2026-08-15 in the changelog
- prepare the exact commit that will receive the `v3.0.0` tag

## Validation

- `git diff --check`

After this PR is merged and Trusted Publishing is configured, the annotated `v3.0.0` tag can be pushed to trigger the release workflow.